### PR TITLE
Fix NuGet publish step on Ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,11 +69,13 @@ steps:
   inputs:
     ArtifactName: '$(Build.BuildNumber)'
 
-- task: NuGetCommand@2
+- task: NuGetAuthenticate@1
+  condition: and(succeeded(), eq(variables._publishNugetPackages, 'true'))
+  displayName: 'Authenticate NuGet'
+
+- script: |
+    find "$(Build.ArtifactStagingDirectory)" -name "*.nupkg" ! -name "*.symbols.nupkg" -print0 | while IFS= read -r -d '' package; do
+      dotnet nuget push "$package" --source "http-server-sim" --skip-duplicate
+    done
   condition: and(succeeded(), eq(variables._publishNugetPackages, 'true'))
   displayName: 'Publish NuGet Packages'
-  inputs:
-    command: 'push'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
-    nuGetFeedType: 'external'
-    publishFeedCredentials: 'http-server-sim'


### PR DESCRIPTION
## Summary
- replace the Mono-dependent `NuGetCommand@2` publish step
- authenticate with `NuGetAuthenticate@1`
- publish packages with `dotnet nuget push`
- continue excluding `.symbols.nupkg` files

## Reason
The Azure pipeline publish step fails on Ubuntu 24.04+ because `NuGetCommand@2` depends on `nuget.exe` and Mono.

## Validation
- reviewed the Azure pipeline failure output
- updated the publish flow in `azure-pipelines.yml` to use the .NET CLI instead of `NuGetCommand@2`
